### PR TITLE
create_task_enter_form

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,8 +6,20 @@ class TasksController < ApplicationController
   end
 
   def new
+    @task = Task.new
+  end
+
+  def create
+    @task = Task.new(task_params)
+    @task.save
+    redirect_to tasks_path, notice: "タスク「#{@task.name}」を登録しました。"
   end
 
   def edit
+  end
+
+  private
+  def task_params
+   params.require(:task).permit(:name, :description) 
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,4 +12,6 @@ html
   .app-title.navbar.navbar-expand-md.navbar-light.bg-light
     .navbar-brand Taskleaf
   .container
+    - if flash.notice.present?
+      .alert.alert-primary = flash.notice
     = yield

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,2 +1,2 @@
-h1 Tasks#index
-p Find me in app/views/tasks/index.html.slim
+h1 タスク一覧
+= link_to '新規登録', new_task_path, class: 'btn btn-primary'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#new
-p Find me in app/views/tasks/new.html.slim
+h1 タスクの新規登録
+
+.nav.justify-content-end 
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_name'
+  = f.submit nil, class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,3 @@
----
 ja:
   activerecord:
     errors:
@@ -7,6 +6,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: 名称
+        description: 詳しい説明
+        created_at: 登録日時
+        update_at: 更新日時
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
新規登録機能を実装した。

①新規登録画面を実装するためにインスタンス変数(@task)をコントローラのnewアクションに設定した。
※インスタンス変数(@task)がないとアクションからビューにデータの受け渡しができなくなる。

②新規登録画面のビューの実装をするためにform_withメソッドを使用した。
※form_withメソッドを使用することでモデル(task)の属性(name, description)と対応つける。
※label・text_area・text_field・submitメソッドを使用してラベル・入力欄・ボタンを作成した。

③ createアクションのparamsはnewアクションで作成された値を受け取るために使われるメソッドである。また、saveメソッドを使用してparamsで取得した値をdbに保存する。
※登録、更新、削除した新しいデータをブラウザに表示させたい場合はredirect_toを使用する。
※createアクションではフォームから送られてきた値が不正なデータではないかstrong parametersでdbに入れる値を制限する。

④ページが切り替わったときにメッセージを表示させるようにFlashメッセージを実装した。処理が成功した場合は[:notice]キーを使用し、失敗した場合は[:alert]キーを使用する。railsのデフォルトではnoticeとalertのキーがある
