### PR TITLE
common_template

### DIFF
--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_name'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,5 @@ h1 タスクの編集
 .nav.justify-content-end 
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_name'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task}
+

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-end 
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_name'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task}


### PR DESCRIPTION
新規登録画面と編集画面の共通化をした。

①共通化をするには部分テンプレートとして先頭に_をつけたファイルを作成する。(_form.html.slim) 

②localsオプションを使用することでインスタンス変数@taskを部分テンプレート内のローカル変数taskに
定義でき、部分テンプレート内で変数を使用できる。