### PR TITLE
create_task_destroy

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,6 +27,12 @@ class TasksController < ApplicationController
     redirect_to tasks_path, notice: "タスク「#{@task.name}」を更新しました。"
   end
 
+  def destroy
+    @task = Task.find(params[:id])
+    @task.destroy
+    redirect_to tasks_path, notice: "タスク「#{@task.name}」を削除しました。"
+  end
+
   private
   def task_params
    params.require(:task).permit(:name, :description) 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -15,3 +15,4 @@ table.table.table-hover
       td= task.created_at
       td
         = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+        = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,3 +20,4 @@ table.table.table-hover
     th= Task.human_attribute_name(:updated_at)
     td= @task.updated_at
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'


### PR DESCRIPTION
削除機能を実装した。

①destroyアクションではeditアクションと同様でlink_toメソッドで送られてきた値(id)をparamsで受け取りfindメソッドでデータベースから該当するデータを取り出している。その後にdestroyメソッドでレコードをデータベースから削除している。

②削除画面についてはlink_toのdataオプションに"confirm: メッセージ内容"を渡すことで確認ダイアログが表示されるように設定ができる。