### PR TITLE
add_NOTNULL

### DIFF
--- a/db/migrate/20210418071940_change_tasks_name_not_null.rb
+++ b/db/migrate/20210418071940_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_111640) do
+ActiveRecord::Schema.define(version: 2021_04_18_071940) do
 
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
NOT NULL制約について学んだ。

①docker-compose run web bundle exec rails g migrate ChangeTasksNameNotNull
※テーブルを作成し終わってから制約をつける場合は変更用のマイグレーションファイルを作成する。

②変更用のマイグレーションファイルに"change_column_null :tasks, :name, false"と書くとtasksテーブルのnameカラムにNULLを入れることができなくなる。

③docker-compose run web bundle exec rails db:migrate  
※変更したマイグレーションをデータベースに適用する。