### PR TITLE
add_limit30

### DIFF
--- a/db/migrate/20210420050237_change_tasks_name_limit30.rb
+++ b/db/migrate/20210420050237_change_tasks_name_limit30.rb
@@ -1,0 +1,9 @@
+class ChangeTasksNameLimit30 < ActiveRecord::Migration[6.1]
+  def up
+    change_column :tasks, :name, :string, limit: 30
+  end
+
+  def down
+    change_column :tasks, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_18_071940) do
+ActiveRecord::Schema.define(version: 2021_04_20_050237) do
 
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name", limit: 30, null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
文字列の長さを30文字に制限した。

①docker-compose run web bundle exec rails g migrate ChangeTasksNameLimit30
※テーブルを作成し終わってから制約をつける場合は変更用のマイグレーションファイルを作成する。

②"change_column"を"change"メソッドで使用すると元に戻せなくなるため"up"と"down"メソッドを使用している

③docker-compose run web bundle exec rails db:migrate  
※変更したマイグレーションをデータベースに適用する。